### PR TITLE
Exit with a non-zero error code on exceptions

### DIFF
--- a/imguralbum.py
+++ b/imguralbum.py
@@ -105,7 +105,9 @@ if __name__ == '__main__':
 			albumFolder = False
 		
 		downloader.save_images(albumFolder)
+		exit()
 	except ImgurAlbumException as e:
 		print "Error: " + e.msg
 		print ""
 		print help_message
+		exit(1)


### PR DESCRIPTION
Making the script return 1 on exceptions, because it is useful while scripting.
