### PR TITLE
Ordered files

### DIFF
--- a/imguralbum.py
+++ b/imguralbum.py
@@ -11,6 +11,7 @@ import sys
 import re
 import urllib
 import os
+import math
 
 help_message = '''
 Quickly and easily download an album from Imgur.
@@ -76,10 +77,13 @@ class ImgurAlbumDownloader:
             os.makedirs(albumFolder)
 
         # And finally loop through and save the images:
-        for image in self.images:
+        for (counter, image) in enumerate(self.images, start=1):
             if self.output_messages:
                 print "Fetching Image: " + image[0]
-            path = os.path.join(albumFolder, image[1])
+            prefix = "%0*d-" % (
+                int(math.ceil(math.log(len(self.images) + 1, 10))),
+                counter)
+            path = os.path.join(albumFolder, prefix + image[1])
             urllib.urlretrieve(image[0], path)
 
         if self.output_messages:


### PR DESCRIPTION
This PR does 2 things:
1.  Cleans up the file so it adheres to the PEP8 Python Style Guide (I used SublimeLinter to do the cleaning up)
2.  Prefixes the images with the sequence number of the images in the imgur album so the files can be sorted by its original ordering in the album.

I'm not sure if we want to preserve the original filenames of the files, but if we want that, we can make the addition of the ordering prefix an optional behavior, i.e. by adding a command line option of `--ordered`, for example.  Just let me know if we want that and I'll do it.
