### PR TITLE
Allow mobile links to be valid

### DIFF
--- a/imguralbum.py
+++ b/imguralbum.py
@@ -47,7 +47,7 @@ class ImgurAlbumDownloader:
         self.complete_callbacks = []
 
         # Check the URL is actually imgur:
-        match = re.match('(https?)\:\/\/(www\.)?imgur\.com/a/([a-zA-Z0-9]+)(#[0-9]+)?', album_url)
+        match = re.match('(https?)\:\/\/(www\.)?(?:m\.)?imgur\.com/a/([a-zA-Z0-9]+)(#[0-9]+)?', album_url)
         if not match:
             raise ImgurAlbumException("URL must be a valid Imgur Album")
 


### PR DESCRIPTION
Extremely simple patch. This makes it so mobile links are valid and can be downloaded.

e.g. http://m.imgur.com/a/NMauG used to be invalid but now it's valid and able to be downloaded.
